### PR TITLE
Add namespace TMVA::Experimental::SOFIE::INTERNAL to LinkDef

### DIFF
--- a/tmva/sofie/inc/LinkDef.h
+++ b/tmva/sofie/inc/LinkDef.h
@@ -8,6 +8,7 @@
 #pragma link C++ nestedclass;
 
 #pragma link C++ namespace TMVA::Experimental::SOFIE;
+#pragma link C++ namespace TMVA::Experimental::SOFIE::INTERNAL;
 #pragma link C++ class TMVA::Experimental::SOFIE::RModel-;
 #pragma link C++ class TMVA::Experimental::SOFIE::ROperator+;
 #pragma link C++ struct TMVA::Experimental::SOFIE::InitializedTensor+;


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Fixes:
```
IncrementalExecutor::executeFunction: symbol 'TMVA::Experimental::SOFIE::INTERNAL::make_ROperator_Reshape(onnx::NodeProto const&, onnx::GraphProto const&, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, TMVA::Experimental::SOFIE::ETensorType, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, TMVA::Experimental::SOFIE::ETensorType> > >&)' unresolved while linking function '_GLOBAL__sub_I_cling_module_0'!
You are probably missing the definition of TMVA::Experimental::SOFIE::INTERNAL::make_ROperator_Reshape(onnx::NodeProto const&, onnx::GraphProto const&, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, TMVA::Experimental::SOFIE::ETensorType, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, TMVA::Experimental::SOFIE::ETensorType> > >&)
Maybe you need to load the corresponding shared library?
IncrementalExecutor::executeFunction: symbol 'TMVA::Experimental::SOFIE::INTERNAL::make_ROperator_Pool(onnx::NodeProto const&, onnx::GraphProto const&, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, TMVA::Experimental::SOFIE::ETensorType, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, TMVA::Experimental::SOFIE::ETensorType> > >&)' unresolved while linking function '_GLOBAL__sub_I_cling_module_0'!
You are probably missing the definition of TMVA::Experimental::SOFIE::INTERNAL::make_ROperator_Pool(onnx::NodeProto const&, onnx::GraphProto const&, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, TMVA::Experimental::SOFIE::ETensorType, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, TMVA::Experimental::SOFIE::ETensorType> > >&)
Maybe you need to load the corresponding shared library?
IncrementalExecutor::executeFunction: symbol 'TMVA::Experimental::SOFIE::INTERNAL::make_ROperator_RNN(onnx::NodeProto const&, onnx::GraphProto const&, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, TMVA::Experimental::SOFIE::ETensorType, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, TMVA::Experimental::SOFIE::ETensorType> > >&)' unresolved while linking function '_GLOBAL__sub_I_cling_module_0'!
You are probably missing the definition of TMVA::Experimental::SOFIE::INTERNAL::make_ROperator_RNN(onnx::NodeProto const&, onnx::GraphProto const&, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, TMVA::Experimental::SOFIE::ETensorType, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, TMVA::Experimental::SOFIE::ETensorType> > >&)
Maybe you need to load the corresponding shared library?
IncrementalExecutor::executeFunction: symbol 'TMVA::Experimental::SOFIE::INTERNAL::make_ROperator_Add(onnx::NodeProto const&, onnx::GraphProto const&, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, TMVA::Experimental::SOFIE::ETensorType, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, TMVA::Experimental::SOFIE::ETensorType> > >&)' unresolved while linking function '_GLOBAL__sub_I_cling_module_0'!
You are probably missing the definition of TMVA::Experimental::SOFIE::INTERNAL::make_ROperator_Add(onnx::NodeProto const&, onnx::GraphProto const&, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, TMVA::Experimental::SOFIE::ETensorType, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, TMVA::Experimental::SOFIE::ETensorType> > >&)
Maybe you need to load the corresponding shared library?
IncrementalExecutor::executeFunction: symbol 'TMVA::Experimental::SOFIE::INTERNAL::make_ROperator_GRU(onnx::NodeProto const&, onnx::GraphProto const&, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, TMVA::Experimental::SOFIE::ETensorType, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, TMVA::Experimental::SOFIE::ETensorType> > >&)' unresolved while linking function '_GLOBAL__sub_I_cling_module_0'!
You are probably missing the definition of TMVA::Experimental::SOFIE::INTERNAL::make_ROperator_GRU(onnx::NodeProto const&, onnx::GraphProto const&, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, TMVA::Experimental::SOFIE::ETensorType, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, TMVA::Experimental::SOFIE::ETensorType> > >&)
Maybe you need to load the corresponding shared library?
IncrementalExecutor::executeFunction: symbol 'TMVA::Experimental::SOFIE::INTERNAL::make_ROperator_Selu(onnx::NodeProto const&, onnx::GraphProto const&, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, TMVA::Experimental::SOFIE::ETensorType, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, TMVA::Experimental::SOFIE::ETensorType> > >&)' unresolved while linking function '_GLOBAL__sub_I_cling_module_0'!
You are probably missing the definition of TMVA::Experimental::SOFIE::INTERNAL::make_ROperator_Selu(onnx::NodeProto const&, onnx::GraphProto const&, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, TMVA::Experimental::SOFIE::ETensorType, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, TMVA::Experimental::SOFIE::ETensorType> > >&)
Maybe you need to load the corresponding shared library?
IncrementalExecutor::executeFunction: symbol 'TMVA::Experimental::SOFIE::INTERNAL::make_ROperator_Transpose(onnx::NodeProto const&, onnx::GraphProto const&, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, TMVA::Experimental::SOFIE::ETensorType, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, TMVA::Experimental::SOFIE::ETensorType> > >&)' unresolved while linking function '_GLOBAL__sub_I_cling_module_0'!
You are probably missing the definition of TMVA::Experimental::SOFIE::INTERNAL::make_ROperator_Transpose(onnx::NodeProto const&, onnx::GraphProto const&, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, TMVA::Experimental::SOFIE::ETensorType, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, TMVA::Experimental::SOFIE::ETensorType> > >&)
Maybe you need to load the corresponding shared library?
IncrementalExecutor::executeFunction: symbol 'TMVA::Experimental::SOFIE::INTERNAL::make_ROperator_Gemm(onnx::NodeProto const&, onnx::GraphProto const&, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, TMVA::Experimental::SOFIE::ETensorType, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, TMVA::Experimental::SOFIE::ETensorType> > >&)' unresolved while linking function '_GLOBAL__sub_I_cling_module_0'!
You are probably missing the definition of TMVA::Experimental::SOFIE::INTERNAL::make_ROperator_Gemm(onnx::NodeProto const&, onnx::GraphProto const&, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, TMVA::Experimental::SOFIE::ETensorType, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, TMVA::Experimental::SOFIE::ETensorType> > >&)
Maybe you need to load the corresponding shared library?
IncrementalExecutor::executeFunction: symbol 'TMVA::Experimental::SOFIE::INTERNAL::make_ROperator_BatchNormalization(onnx::NodeProto const&, onnx::GraphProto const&, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, TMVA::Experimental::SOFIE::ETensorType, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, TMVA::Experimental::SOFIE::ETensorType> > >&)' unresolved while linking function '_GLOBAL__sub_I_cling_module_0'!
You are probably missing the definition of TMVA::Experimental::SOFIE::INTERNAL::make_ROperator_BatchNormalization(onnx::NodeProto const&, onnx::GraphProto const&, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, TMVA::Experimental::SOFIE::ETensorType, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, TMVA::Experimental::SOFIE::ETensorType> > >&)
Maybe you need to load the corresponding shared library?
IncrementalExecutor::executeFunction: symbol 'TMVA::Experimental::SOFIE::INTERNAL::make_ROperator_Slice(onnx::NodeProto const&, onnx::GraphProto const&, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, TMVA::Experimental::SOFIE::ETensorType, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, TMVA::Experimental::SOFIE::ETensorType> > >&)' unresolved while linking function '_GLOBAL__sub_I_cling_module_0'!
You are probably missing the definition of TMVA::Experimental::SOFIE::INTERNAL::make_ROperator_Slice(onnx::NodeProto const&, onnx::GraphProto const&, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, TMVA::Experimental::SOFIE::ETensorType, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, TMVA::Experimental::SOFIE::ETensorType> > >&)
Maybe you need to load the corresponding shared library?
IncrementalExecutor::executeFunction: symbol 'TMVA::Experimental::SOFIE::INTERNAL::make_ROperator_Sigmoid(onnx::NodeProto const&, onnx::GraphProto const&, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, TMVA::Experimental::SOFIE::ETensorType, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, TMVA::Experimental::SOFIE::ETensorType> > >&)' unresolved while linking function '_GLOBAL__sub_I_cling_module_0'!
You are probably missing the definition of TMVA::Experimental::SOFIE::INTERNAL::make_ROperator_Sigmoid(onnx::NodeProto const&, onnx::GraphProto const&, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, TMVA::Experimental::SOFIE::ETensorType, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, TMVA::Experimental::SOFIE::ETensorType> > >&)
Maybe you need to load the corresponding shared library?
IncrementalExecutor::executeFunction: symbol 'TMVA::Experimental::SOFIE::INTERNAL::make_ROperator_Relu(onnx::NodeProto const&, onnx::GraphProto const&, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, TMVA::Experimental::SOFIE::ETensorType, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, TMVA::Experimental::SOFIE::ETensorType> > >&)' unresolved while linking function '_GLOBAL__sub_I_cling_module_0'!
You are probably missing the definition of TMVA::Experimental::SOFIE::INTERNAL::make_ROperator_Relu(onnx::NodeProto const&, onnx::GraphProto const&, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, TMVA::Experimental::SOFIE::ETensorType, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, TMVA::Experimental::SOFIE::ETensorType> > >&)
Maybe you need to load the corresponding shared library?
IncrementalExecutor::executeFunction: symbol 'TMVA::Experimental::SOFIE::INTERNAL::make_ROperator_Conv(onnx::NodeProto const&, onnx::GraphProto const&, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, TMVA::Experimental::SOFIE::ETensorType, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, TMVA::Experimental::SOFIE::ETensorType> > >&)' unresolved while linking function '_GLOBAL__sub_I_cling_module_0'!
You are probably missing the definition of TMVA::Experimental::SOFIE::INTERNAL::make_ROperator_Conv(onnx::NodeProto const&, onnx::GraphProto const&, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, TMVA::Experimental::SOFIE::ETensorType, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, TMVA::Experimental::SOFIE::ETensorType> > >&)
Maybe you need to load the corresponding shared library?
IncrementalExecutor::executeFunction: symbol 'TMVA::Experimental::SOFIE::INTERNAL::make_ROperator_LSTM(onnx::NodeProto const&, onnx::GraphProto const&, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, TMVA::Experimental::SOFIE::ETensorType, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, TMVA::Experimental::SOFIE::ETensorType> > >&)' unresolved while linking function '_GLOBAL__sub_I_cling_module_0'!
You are probably missing the definition of TMVA::Experimental::SOFIE::INTERNAL::make_ROperator_LSTM(onnx::NodeProto const&, onnx::GraphProto const&, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, TMVA::Experimental::SOFIE::ETensorType, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, TMVA::Experimental::SOFIE::ETensorType> > >&)
Maybe you need to load the corresponding shared library?

```
etc output on startup.

## Checklist:

- [ ] tested changes locally

This PR fixes #10877


Note: still need to double check locally

